### PR TITLE
Feat extract alt text from xkcd rss feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Feel free for any pull request or to make a request for a new comic (if I have t
 - [The awkward yeti](https://theawkwardyeti.com/)
 - [Buttersafe](https://www.buttersafe.com/)
 - [buni](https://www.bunicomic.com/)
-
+- [xkcd](https://xkcd.com/)
 
 ## Changelog
 

--- a/comics/loader.php
+++ b/comics/loader.php
@@ -6,5 +6,6 @@ require_once __DIR__ . '/buttersafe.php';
 require_once __DIR__ . '/theawkwardyeti.php';
 //buni
 require_once __DIR__ . '/buni.php';
-
+//xkcd
+require_once __DIR__ . '/xkcd.php';
 ?>

--- a/comics/xkcd.php
+++ b/comics/xkcd.php
@@ -1,0 +1,27 @@
+<?php
+
+
+/**
+  Parse xkcd feed.
+
+  The xkcd feed contains the image, but half of the comedy is in the hover-over
+  alt text. This parser extracts out the alt text.
+*/
+function parseXkcd($entry){
+
+  $dom = new DOMDocument;
+  $dom->loadHTML($entry->content());
+  libxml_use_internal_errors(false);
+
+  $image = $dom->getElementsByTagName('img')[0];
+  if (!is_null($image)) {
+    $alt = $image->getAttribute('alt');
+    $text = $dom->createElement('p', $alt);
+    $body = $dom->getElementsByTagName('body')->item(0);
+    $body->appendChild($text);
+    $entry->_content($dom->saveHTML());
+  }
+
+  return $entry;
+}
+

--- a/extension.php
+++ b/extension.php
@@ -63,6 +63,10 @@ class ComicsInFeedExtension extends Minz_Extension{
         if (!stripos($link, 'bunicomic.com') === false ) {
             return 3;
         }
+        //xkcd
+        if (!stripos($link, 'xkcd.com') === false ) {
+            return 4;
+        }
 
         return 0;
     }
@@ -91,6 +95,10 @@ class ComicsInFeedExtension extends Minz_Extension{
             }
             case 3: {
                 $entry = parseBuni($entry);
+                break;
+            }
+            case 4: {
+                $entry = parseXkcd($entry);
                 break;
             }
         }


### PR DESCRIPTION
Half of the comedy, in xkcd, is hidden in the `alt` text field. Explicitly extracting it out, to save mouse hovering (or in cases where the RSS feed client does not support `alt` text fields).