### PR TITLE
Add new comic parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Feel free for any pull request or to make a request for a new comic (if I have t
 - [xkcd](https://xkcd.com/)
 - [Explosm](https://explosm.net/) ([RSS feed](https://explosm.net/rss.xml))
 - [The Monster under the bed](https://www.themonsterunderthebed.net/)
+- [Flipside](https://flipside.gushi.org) ([RSS feed](https://flipsidecomics.com/flipsiderss.php))
+- [Girl Genius](https://www.girlgeniusonline.com/comic.php)
+- [Questionable Content](https://questionablecontent.net/)
+- [Sluggy Freelance](https://sluggy.com/)
 
 
 ## Changelog
@@ -58,7 +62,7 @@ Feel free for any pull request or to make a request for a new comic (if I have t
   - Added [Explosm](https://explosm.net/) from hidden xml rss feed thanks to [wiiaboo](https://github.com/wiiaboo)
 
 #### 1.2
- 
+
 6 December 2023
   - Added [xkcd](https://xkcd.com/) images alt text, thanks to [jackson15j](https://github.com/jackson15j)
   - Penny Arcade [Penny-Arcade](https://penny-arcade.com/), thanks to [jackson15j](https://github.com/jackson15j)

--- a/comics/flipside.php
+++ b/comics/flipside.php
@@ -1,0 +1,33 @@
+<?php
+
+/** Parse Flipside feed
+ *
+ * The feed contents do not contain the comic, we have to load the link and
+ * parse the page.
+*/
+function parseFlipside($entry) {
+	$dom = new DOMDocument;
+	libxml_use_internal_errors(false);
+
+	$comicURL = $entry->link();
+	$comicDOM = new DOMDocument;
+	$comicDOM->loadHTMLFile($comicURL, LIBXML_NOWARNING | LIBXML_NOERROR);
+
+	$imageContainer = $comicDOM->getElementById('flip_comicpage');
+	if (is_null($imageContainer)) {
+		return $entry;
+	}
+
+	$imageLinkNode = $imageContainer->getElementsByTagName('a')->item(0);
+	$imageNode = $imageLinkNode->getElementsByTagName('img')->item(0);
+	// The image URL doesn't contain the domain
+	$imageURL = 'https://flipside.gushi.org' . $imageNode->getAttribute('src');
+
+	$image = $dom->createElement('img');
+	$image->setAttribute('src', $imageURL);
+
+  $dom->append($image);
+	$entry->_content($dom->saveHTML());
+
+	return $entry;
+}

--- a/comics/girlgenius.php
+++ b/comics/girlgenius.php
@@ -1,0 +1,47 @@
+<?php
+
+/** Parse Girl Genius Online feed
+ *
+ * The feed contents do not contain the comic, load the link and parse the page
+ */
+function parseGirlGenius($entry) {
+	$dom = new DOMDocument;
+	$dom->loadHTML($entry->content());
+	libxml_use_internal_errors(false);
+
+	$comicURL = $entry->link();
+	$comicDOM = new DOMDocument;
+	$comicDOM->loadHTMLFile($comicURL, LIBXML_NOWARNING | LIBXML_NOERROR);
+
+	$imageContainer = $comicDOM->getElementById('comicbody');
+	if (is_null($imageContainer)) {
+		return $entry;
+	}
+
+	$imageNode = null;
+	$imageNodes = $imageContainer->getElementsByTagName('img');
+	$imageCount = $imageNodes->length;
+	for ($idx = 0; $idx < $imageCount; $idx++) {
+		$candidate = $imageNodes->item($idx);
+		if ($candidate->getAttribute('alt') === 'Comic') {
+			$imageNode = $candidate;
+			break;
+		}
+	}
+	if (is_null($imageNode)) {
+		return $entry;
+	}
+	$imageURL = str_replace('http://', 'https://', $imageNode->getAttribute('src'));
+
+	$image = $dom->createElement('img');
+	$image->setAttribute('src', $imageURL);
+
+	$body = $dom->getElementsByTagName('body')->item(0);
+  while ($body->hasChildNodes()) {
+		$body->removeChild($body->firstChild);
+	}
+	$body->appendChild($image);
+	$entry->_content($dom->saveHTML());
+
+	return $entry;
+}

--- a/comics/loader.php
+++ b/comics/loader.php
@@ -14,5 +14,13 @@ require_once __DIR__ . '/penny-arcade.php';
 require_once __DIR__ . '/explosm.php';
 //monster under the bed
 require_once __DIR__ . '/monsterunderbed.php';
+//Sluggy Freelance
+require_once __DIR__ . '/sluggy.php';
+//Girl Genius
+require_once __DIR__ . '/girlgenius.php';
+//Questionable Content
+require_once __DIR__ . '/questionablecontent.php';
+//Flipside
+require_once __DIR__ . '/flipside.php';
 
 ?>

--- a/comics/questionablecontent.php
+++ b/comics/questionablecontent.php
@@ -1,0 +1,26 @@
+<?php
+
+/** Parse Questionable Content feed
+ *
+ * The feed does contain the image, but the link is a http link even though
+ * the site supports HTTPS. This parser just rewrites the image link to use
+ * https://
+ */
+function parseQuestionableContent($entry) {
+	$dom = new DOMDocument;
+	$dom->loadHTML($entry->content());
+  libxml_use_internal_errors(false);
+
+	$imageNodes = $dom->getElementsByTagName('img');
+	if (!is_null($imageNodes)) {
+		$imageCount = $imageNodes->length;
+		for ($idx = 0; $idx < $imageCount; $idx++) {
+			$image = $imageNodes->item($idx);
+			$imageURL = str_replace('http://', 'https://', $image->getAttribute('src'));
+			$image->setAttribute('src', $imageURL);
+		}
+	}
+	$entry->_content($dom->saveHTML());
+
+	return $entry;
+}

--- a/comics/sluggy.php
+++ b/comics/sluggy.php
@@ -1,0 +1,42 @@
+<?php
+
+/** Parse Sluggy Freelance feed
+ *
+ * The feed does not contain the comic, we have to load the page and parse it out.
+ */
+function parseSluggyFreelance($entry) {
+	$dom = new DOMDocument;
+	$dom->loadHTML($entry->content());
+	libxml_use_internal_errors(false);
+
+	$comicURL = $entry->link();
+	$comicDOM = new DOMDocument;
+	$comicDOM->loadHTMLFile($comicURL, LIBXML_NOWARNING | LIBXML_NOERROR);
+
+	$imageNode = null;
+	$divList = $comicDOM->getElementsByTagName('div');
+	$divCount = $divList->length;
+	for ($idx = 0; $idx < $divCount; $idx++) {
+		$candidate = $divList->item($idx);
+		if ($candidate->getAttribute("class") === 'comic_content') {
+			$imageNode = $candidate->getElementsByTagName('img')->item(0);
+			break;
+		}
+	}
+	if (is_null($imageNode)) {
+		return $entry;
+	}
+
+	$image = $dom->createElement('img');
+	$image->setAttribute('src', $imageNode->getAttribute('src'));
+
+	$body = $dom->getElementsByTagName('body')->item(0);
+  // The feed doesn't have any useful content
+	while ($body->hasChildNodes()) {
+		$body->removeChild($body->firstChild);
+	}
+	$body->appendChild($image);
+	$entry->_content($dom->saveHTML());
+
+	return $entry;
+}

--- a/extension.php
+++ b/extension.php
@@ -67,7 +67,7 @@ class ComicsInFeedExtension extends Minz_Extension{
         if (!stripos($link, 'penny-arcade.com') === false ) {
             return 4;
         }
-         //xkcd
+        //xkcd
         if (!stripos($link, 'xkcd.com') === false ) {
            return 5;
         }
@@ -78,8 +78,24 @@ class ComicsInFeedExtension extends Minz_Extension{
         //monster under the bed
         if (!stripos($link, 'themonsterunderthebed.net') === false ) {
             return 7;
-         }
-      
+        }
+        // Sluggy Freelance
+        if (!stripos($link, 'sluggy.com') === false) {
+            return 8;
+        }
+        // Girl Genius
+        if (!stripos($link, 'girlgeniusonline.com') === false) {
+            return 9;
+        }
+        // Questionable Content
+        if (!stripos($link, 'questionablecontent.net') === false) {
+            return 10;
+        }
+        // Flipside
+        if (!stripos($link, 'flipside.gushi.org') === false) {
+            return 11;
+        }
+
         return 0;
     }
 
@@ -124,6 +140,22 @@ class ComicsInFeedExtension extends Minz_Extension{
             case 7: {
               $entry = parseMonsterUnderBed($entry);
               break;
+            }
+            case 8: {
+                $entry = parseSluggyFreelance($entry);
+                break;
+            }
+            case 9: {
+                $entry = parseGirlGenius($entry);
+                break;
+            }
+            case 10: {
+                $entry = parseQuestionableContent($entry);
+                break;
+            }
+            case 11: {
+                $entry = parseFlipside($entry);
+                break;
             }
         }
 


### PR DESCRIPTION
Adds new comic parsers for four comics:

- [Flipside](https://flipside.gushi.org): feed has no content, fetch the link and parse the image to add to the feed entry.
- [Girl Genius](https://www.girlgeniusonline.com/comic.php): feed only contains a generic notice, fetch the link and parse the image to replace the feed entry.
- [Questionable Content](https://questionablecontent.net/): feed uses a `http://` URL for the comic image, replace all `http://` image URLs with `https://` URLs.
- [Sluggy Freelance](https://sluggy.com/): feed does not contain the comic image, fetch the link and parse the image to replace the feed entry.