### PR TITLE
fix: Penny-Arcade parsing on Php 7

### DIFF
--- a/comics/penny-arcade.php
+++ b/comics/penny-arcade.php
@@ -53,6 +53,15 @@ function parsePennyArcade($entry){
   // Get link to comic page from RSS Feed Entry..
   $comicUrl = $entry->link();
 
+  // Polyfill for PHP 4 - PHP 7, safe to utilize with PHP 8.
+  // From: https://www.php.net/manual/en/function.str-contains.php
+  if (!function_exists('str_contains')) {
+      function str_contains (string $haystack, string $needle)
+      {
+          return empty($needle) || strpos($haystack, $needle) !== false;
+      }
+  }
+
   if (str_contains($comicUrl, 'news')) {
       // Early return on news entries!
       return $entry;


### PR DESCRIPTION
Recently switched from the [LinuxServer - FreshRSS](https://docs.linuxserver.io/images/docker-freshrss/) docker image to the official [FreshRSS](https://github.com/FreshRSS/FreshRSS) image.

Sadly this broke the parsing since `str-contains()` built-in didn't exist in PHP7 (which is what the official FreshRSS image is built on), but does exist in PHP8 (LinuxServer image is built on).

Naively picked one of the solutions from the comments in: [PHP Docs: `str-contains`](https://www.php.net/manual/en/function.str-contains.php). To get the parsing working again.